### PR TITLE
feat(api): improve error handling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -353,10 +353,10 @@ impl RapiClient for RapiReqwestClient {
 }
 
 fn api_error_adapter(error: reqwest::Error) -> ApiError {
-    if let Some(status) = error.status() {
-        match status {
+    if let Some(status_code) = error.status() {
+        match status_code {
             StatusCode::UNAUTHORIZED => ApiError::Unauthorized { error },
-            _ => ApiError::RequestFailed { error },
+            _ => ApiError::RequestFailedWithCode { status_code, error },
         }
     } else {
         ApiError::RequestFailed { error }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub enum ApiError {
         status_code: StatusCode,
         error: ReqwestError,
     },
+    #[error("Invalid authentication token. Did you supply correct API token?\nerror = {error}")]
+    InvalidAuthenticationToken { error: ReqwestError },
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,48 +1,53 @@
 use std::{io::Write, path::PathBuf};
 
 use console::Style;
-use reqwest::Error as ReqwestError;
+use reqwest::{Error as ReqwestError, StatusCode};
 use thiserror::Error;
 use tokio::{io, task::JoinError};
 use url::ParseError;
 
 #[derive(Error, Debug)]
 pub enum ApiError {
-    #[error("Unauthorized client. Double check you've supplied correct api key or you have appropriate permissions\nerror = ${error}")]
+    #[error("Unauthorized client. Double check you've supplied correct api key or you have appropriate permissions\nerror = {error}")]
     Unauthorized { error: ReqwestError },
     #[error("Invalid parameters for url")]
     InvalidParameters { error: ParseError },
-    #[error("Failed to parse API response\nerror = ${error}")]
+    #[error("Failed to parse API response\nerror = {error}")]
     DeserializationFailure { error: reqwest::Error },
-    #[error("API request failed\nerror = ${error}")]
+    #[error("API request failed\nerror = {error}")]
     RequestFailed { error: ReqwestError },
+    #[error("API request failed\nstatus_code = {status_code}, error = {error}")]
+    RequestFailedWithCode {
+        status_code: StatusCode,
+        error: ReqwestError,
+    },
 }
 
 #[derive(Error, Debug)]
 pub enum ArtifactError {
-    #[error("Failed to retrieve artifact list.\nerror = ${error}")]
+    #[error("Failed to retrieve artifact list.\nerror = {error}")]
     ListFailed { error: JoinError },
 
-    #[error("Failed to download artifacts.\nerror = ${error}")]
+    #[error("Failed to download artifacts.\nerror = {error}")]
     DownloadFailed { error: JoinError },
 }
 
 #[derive(Error, Debug)]
 pub enum InputError {
-    #[error("Invalid input file. Double check you've supplied correct path\npath= ${path}")]
+    #[error("Invalid input file. Double check you've supplied correct path\npath = {path}")]
     InvalidFileName { path: PathBuf },
 
-    #[error("Can't open file. Double check you've supplied correct path\npath= ${path}")]
+    #[error("Can't open file. Double check you've supplied correct path\npath = {path}")]
     OpenFileFailure { path: PathBuf, error: io::Error },
 }
 
 #[derive(Error, Debug)]
 pub enum FilteringConfigurationError {
-    #[error("Filter type ${mtype} is not supported by Marathon Cloud")]
+    #[error("Filter type {mtype} is not supported by Marathon Cloud")]
     UnsupportedFilterType { mtype: String },
-    #[error("Filter type ${mtype} is invalid")]
+    #[error("Filter type {mtype} is invalid")]
     InvalidFilterType { mtype: String },
-    #[error("Invalid configuration for filter ${mtype}: ${message}")]
+    #[error("Invalid configuration for filter {mtype}: {message}")]
     InvalidFilterConfiguration { mtype: String, message: String },
 }
 

--- a/src/interactor.rs
+++ b/src/interactor.rs
@@ -78,6 +78,7 @@ impl TriggerTestRunInteractor {
             _ => 1,
         };
 
+        let token = client.get_token().await?;
         println!(
             "{} Submitting new run...",
             style(format!("[1/{}]", steps)).bold().dim()
@@ -169,7 +170,6 @@ impl TriggerTestRunInteractor {
                             "{} Fetching file list...",
                             style(format!("[3/{}]", steps)).bold().dim()
                         );
-                        let token = client.get_token().await?;
                         let artifacts = fetch_artifact_list(&client, &id, &token).await?;
                         println!(
                             "{} Downloading files...",


### PR DESCRIPTION
Invalid token returns error below fast instead of uploading artifacts and failing afterwards

```
Invalid authentication token. Did you supply correct API token?
error = HTTP status client error (403 Forbidden) for url (https://cloud.marathonlabs.io/xxx)
```

Closes #5 