### PR TITLE
fix(filtering): account for tilde (~) in paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +880,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "shellexpand",
  "simple_logger",
  "tempfile",
  "thiserror",
@@ -1034,6 +1065,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1366,6 +1408,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -1826,6 +1877,28 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,16 +309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,15 +418,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "equivalent"
@@ -589,16 +576,16 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.2.5",
  "slab",
  "tokio",
@@ -648,13 +635,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.6"
+name = "http"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
- "http",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -665,47 +675,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "h2",
- "http",
+ "http 1.1.0",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http",
+ "http 1.1.0",
  "hyper",
+ "hyper-util",
  "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1017,6 +1039,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,20 +1157,20 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "reqwest"
-version = "0.11.26"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
 dependencies = [
- "base64",
+ "base64 0.22.0",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -1139,11 +1181,11 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1237,32 +1279,42 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64",
+ "base64 0.22.0",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -1277,16 +1329,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "semver"
@@ -1373,7 +1415,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1484,6 +1526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,27 +1558,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "tempfile"
@@ -1644,11 +1671,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -1667,6 +1695,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1728,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1874,9 +1925,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -2043,10 +2097,16 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ simple_logger = "4.3.3"
 shellexpand = "3.1.0"
 tempfile = "3.9.0"
 # Reqwest pulls in dependency on openssl which we replace with rustls, hence disabling default features
-reqwest = { version = "0.11.23", default-features = false, features = [
+reqwest = { version = "0.12.3", default-features = false, features = [
   "json",
   "multipart",
   "stream",
@@ -50,7 +50,7 @@ thiserror = "1.0"
 url = "2.5"
 async-stream = "0.3"
 clap_mangen = "0.2.18"
-h2 = "0.3.24"
+h2 = "0.3.26"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0.113"
 serde_yaml = "0.9.31"
 serde_with = "3.6.0"
 simple_logger = "4.3.3"
+shellexpand = "3.1.0"
 tempfile = "3.9.0"
 # Reqwest pulls in dependency on openssl which we replace with rustls, hence disabling default features
 reqwest = { version = "0.11.23", default-features = false, features = [

--- a/fixture/filtering/xctestplan/test plan with spaces.xctestplan
+++ b/fixture/filtering/xctestplan/test plan with spaces.xctestplan
@@ -1,0 +1,83 @@
+{
+  "configurations": [
+    {
+      "id": "8769C931-E688-4F36-BEFF-7625BE7161A9",
+      "name": "Configuration 1",
+      "options": {
+        "addressSanitizer": {
+          "enabled": false
+        },
+        "guardMallocEnabled": false,
+        "mallocGuardEdgesEnabled": false,
+        "mallocScribbleEnabled": false,
+        "mallocStackLoggingOptions": null,
+        "threadSanitizerEnabled": false
+      }
+    }
+  ],
+  "defaultOptions": {
+    "addressSanitizer": {
+      "detectStackUseAfterReturn": true,
+      "enabled": true
+    },
+    "areLocalizationScreenshotsEnabled": true,
+    "codeCoverage": false,
+    "commandLineArgumentEntries": [
+      {
+        "argument": "-test"
+      }
+    ],
+    "diagnosticCollectionPolicy": "Never",
+    "environmentVariableEntries": [
+      {
+        "key": "A",
+        "value": "B"
+      }
+    ],
+    "guardMallocEnabled": true,
+    "language": "en-AU",
+    "locationScenario": {
+      "identifier": "Sydney, Australia",
+      "referenceType": "built-in"
+    },
+    "mainThreadCheckerEnabled": false,
+    "mallocGuardEdgesEnabled": true,
+    "mallocScribbleEnabled": true,
+    "mallocStackLoggingOptions": {
+      "loggingType": "allAllocations"
+    },
+    "nsZombieEnabled": true,
+    "preferredScreenCaptureFormat": "screenshot",
+    "region": "AU",
+    "targetForVariableExpansion": {
+      "containerPath": "container:sample-app.xcodeproj",
+      "identifier": "1271DCB421351C6D002B8D3E",
+      "name": "sample-appUITests"
+    },
+    "testExecutionOrdering": "random",
+    "testRepetitionMode": "retryOnFailure",
+    "testTimeoutsEnabled": true,
+    "threadSanitizerEnabled": true,
+    "uiTestingScreenshotsLifetime": "keepAlways",
+    "undefinedBehaviorSanitizerEnabled": true,
+    "userAttachmentLifetime": "keepAlways"
+  },
+  "testTargets": [
+    {
+      "parallelizable": true,
+      "skippedTests": [
+        "CrashingTests",
+        "MoreTests/testDismissModal()",
+        "SlowTests/testTextSlow1",
+        "SlowTests\/testTextSlow2()",
+        "SlowTests\/testTextSlow3"
+      ],
+      "target": {
+        "containerPath": "container:sample-app.xcodeproj",
+        "identifier": "1271DCB421351C6D002B8D3E",
+        "name": "sample-appUITests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,9 @@ pub enum InputError {
 
     #[error("Invalid xctestplan file: no test targets specified. Double check you've supplied correct path")]
     XctestplanMissingTargets,
+
+    #[error("Invalid input file. All file paths should be valid UTF8\npath = {path}")]
+    NonUTF8Path { path: PathBuf },
 }
 
 #[derive(Error, Debug)]

--- a/src/filtering/convert.rs
+++ b/src/filtering/convert.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
+use shellexpand;
 use std::path::{Path, PathBuf};
 use tokio::{
     fs::{self, File},
     io::AsyncReadExt,
 };
-use shellexpand;
 
 use crate::errors::{FilteringConfigurationError, InputError};
 
@@ -14,13 +14,17 @@ use super::{
 };
 
 pub async fn convert(cnf: PathBuf) -> Result<SparseMarathonfile> {
-    let expanded_path = shellexpand::tilde(cnf.to_str().unwrap()).into_owned();
-    let content = fs::read_to_string(&expanded_path)
-        .await
-        .map_err(|error| InputError::OpenFileFailure {
-            path: PathBuf::from(&expanded_path),
-            error,
-        })?;
+    let path = cnf.to_str().ok_or(InputError::NonUTF8Path {
+        path: cnf.to_owned(),
+    })?;
+    let expanded_path = shellexpand::tilde(&path).into_owned();
+    let content =
+        fs::read_to_string(&expanded_path)
+            .await
+            .map_err(|error| InputError::OpenFileFailure {
+                path: PathBuf::from(&expanded_path),
+                error,
+            })?;
 
     let mut filtering_configuration: SparseMarathonfile = serde_yaml::from_str(&content)?;
 
@@ -39,13 +43,17 @@ pub async fn convert_xctestplan(
     cnf: PathBuf,
     target_name: Option<String>,
 ) -> Result<SparseMarathonfile> {
-    let expanded_path = shellexpand::tilde(cnf.to_str().unwrap()).into_owned();
-    let content = fs::read_to_string(&expanded_path)
-        .await
-        .map_err(|error| InputError::OpenFileFailure {
-            path: PathBuf::from(&expanded_path),
-            error,
-        })?;
+    let path = cnf.to_str().ok_or(InputError::NonUTF8Path {
+        path: cnf.to_owned(),
+    })?;
+    let expanded_path = shellexpand::tilde(&path).into_owned();
+    let content =
+        fs::read_to_string(&expanded_path)
+            .await
+            .map_err(|error| InputError::OpenFileFailure {
+                path: PathBuf::from(&expanded_path),
+                error,
+            })?;
 
     let xctestplan: xctestplan::SparseTestPlan = serde_json::from_str(&content)?;
     let targets = xctestplan.test_targets;
@@ -278,7 +286,7 @@ async fn validate_filter(
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use std::path::Path;
+    use std::path::{self, Path};
 
     use crate::filtering::convert::{convert, convert_xctestplan};
 
@@ -302,7 +310,8 @@ mod tests {
     async fn test_valid_with_tilde_in_path() -> Result<()> {
         let mut manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let home_dir = std::env::var("HOME").unwrap();
-        manifest_dir = manifest_dir.replace(&home_dir, "~");
+        let suffix = "~".to_owned() + path::MAIN_SEPARATOR_STR;
+        manifest_dir = manifest_dir.replace(&home_dir, &suffix);
         let fixture = Path::new(&manifest_dir)
             .join("fixture")
             .join("filtering")
@@ -459,7 +468,8 @@ mod tests {
     async fn test_xctestplan_with_tilde_in_path() -> Result<()> {
         let mut manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let home_dir = std::env::var("HOME").unwrap();
-        manifest_dir = manifest_dir.replace(&home_dir, "~");
+        let suffix = "~".to_owned() + path::MAIN_SEPARATOR_STR;
+        manifest_dir = manifest_dir.replace(&home_dir, &suffix);
         let fixture = Path::new(&manifest_dir)
             .join("fixture")
             .join("filtering")


### PR DESCRIPTION
## Context
The tool was failing to resolve the path to the filters that contained `~` in the path. This PR resolves the problem by expanding the path to the absolute path by prefixing the path with the correct value of $HOME directory.