### PR TITLE
fix: wait parameter setup was fixed

### DIFF
--- a/src/cli/android/mod.rs
+++ b/src/cli/android/mod.rs
@@ -130,13 +130,19 @@ pub(crate) async fn run(
     let retry_args = cli::validate::retry_args(retry_args);
     cli::validate::result_file_args(&common.result_file_args)?;
 
+    let present_wait: bool = match common.wait {
+        None => true,
+        Some(true) => true,
+        Some(false) => false,
+    };
+
     TriggerTestRunInteractor {}
         .execute(
             &api_args.base_url,
             &api_args.api_key,
             common.name,
             common.link,
-            common.wait,
+            present_wait,
             common.isolated,
             common.ignore_test_failures,
             common.code_coverage,

--- a/src/cli/ios/mod.rs
+++ b/src/cli/ios/mod.rs
@@ -235,13 +235,19 @@ If you provide any single or two of these parameters, the others will be inferre
     let retry_args = cli::validate::retry_args(retry_args);
     cli::validate::result_file_args(&common.result_file_args)?;
 
+    let present_wait: bool = match common.wait {
+        None => true,
+        Some(true) => true,
+        Some(false) => false,
+    };
+
     TriggerTestRunInteractor {}
         .execute(
             &api_args.base_url,
             &api_args.api_key,
             common.name,
             common.link,
-            common.wait,
+            present_wait,
             common.isolated,
             common.ignore_test_failures,
             common.code_coverage,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -195,10 +195,9 @@ struct CommonRunArgs {
 
     #[arg(
         long,
-        default_value_t = true,
         help = "Wait for test run to finish if true, exits after triggering a run if false"
     )]
-    wait: bool,
+    wait: Option<bool>,
 
     #[arg(
         long,


### PR DESCRIPTION
Usage of `wait: bool` instead of `wait: Option<bool>` prevented any possibility to setup `wait` = `false`. 
Also, CLI allowed to use only `--wait` argument without setting the value (only `true` by default).
Now, CLI allows the following setup: `--wait true`, `--wait false`.