### PR TITLE
feat(filtering): support comments in the value files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "indicatif",
  "log",
  "num_cpus",
+ "regex",
  "reqwest",
  "rstest",
  "serde",
@@ -1214,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ h2 = "0.3.26"
 async_zip = { version = "0.0.17", features = ["tokio", "tokio-fs", "deflate"] }
 walkdir = "2.5.0"
 globset = "0.4"
+regex = "1.10.5"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/fixture/filtering/filetype_with_comments.yaml
+++ b/fixture/filtering/filetype_with_comments.yaml
@@ -1,0 +1,4 @@
+filteringConfiguration:
+  allowlist:
+    - type: "fully-qualified-test-name"
+      file: "tests_with_comments.txt"

--- a/fixture/filtering/filetype_with_comments.yaml
+++ b/fixture/filtering/filetype_with_comments.yaml
@@ -1,4 +1,5 @@
-filteringConfiguration:
+filteringConfiguration: #This is our filtering configuration block
   allowlist:
     - type: "fully-qualified-test-name"
+      # The following file contains actual values
       file: "tests_with_comments.txt"

--- a/fixture/filtering/tests_with_comments.txt
+++ b/fixture/filtering/tests_with_comments.txt
@@ -1,0 +1,12 @@
+#line comment
+com.example.test1
+com.example.test2 #issue link = http://test.test/issue
+
+#line comment2
+
+com.example   #flaky package
+
+  # comment3
+ClassName#test4 # comment
+SimpleTestName
+SimpleTestName2 #comment1


### PR DESCRIPTION
Added support for comments in filter value files with `#` sign similar to https://github.com/MarathonLabs/marathon/pull/943