### PR TITLE
feat(s3): support compressed files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "console",
+ "flate2",
  "futures",
  "globset",
  "h2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +419,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -763,10 +783,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core",
  "wasm-bindgen",
 ]
 
@@ -1481,15 +1513,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,15 +1543,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1570,32 +1594,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.3",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2963,26 +2990,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 time = { version = "0.3.47", features = ["serde-well-known"] }
 tokio = { version = "1.51.1", features = ["full"] }
 tokio-util = "0.7.18"
+flate2 = "1"
 futures = "0.3"
 async-trait = "0.1"
 num_cpus = "1"

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use time::OffsetDateTime;
+use flate2::read::GzDecoder;
 use tokio::fs::{create_dir_all, File};
 use tokio::io;
 
@@ -377,7 +378,14 @@ impl RapiClient for RapiReqwestClient {
             .send()
             .await?;
 
-        let mut src = api_error_adapter(src).await?.bytes_stream();
+        let response = api_error_adapter(src).await?;
+        let is_gzip = response
+            .headers()
+            .get(reqwest::header::CONTENT_ENCODING)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v == "gzip")
+            .unwrap_or(false);
+        let mut src = response.bytes_stream();
 
         let dst_dir = absolute_path.parent();
         if let Some(dst_dir) = dst_dir {
@@ -385,10 +393,16 @@ impl RapiClient for RapiReqwestClient {
                 create_dir_all(dst_dir).await?;
             }
         }
-        let mut dst = File::create(absolute_path).await?;
+        let mut dst = File::create(&absolute_path).await?;
 
         while let Some(chunk) = src.next().await {
             io::copy(&mut chunk?.as_ref(), &mut dst).await?;
+        }
+        drop(dst);
+
+        if is_gzip {
+            let path = absolute_path.clone();
+            tokio::task::spawn_blocking(move || decompress_gz_in_place(&path)).await??;
         }
 
         Ok(())
@@ -778,6 +792,27 @@ pub struct RapiError {
     pub message: String,
 }
 
+fn decompress_gz_in_place(path: &Path) -> Result<()> {
+    let gz_file = std::fs::File::open(path)?;
+    let mut decoder = GzDecoder::new(std::io::BufReader::new(gz_file));
+
+    let has_gz_ext = path.extension().and_then(|e| e.to_str()) == Some("gz");
+    if has_gz_ext {
+        let decompressed_path = path.with_extension("");
+        let mut out_file = std::fs::File::create(&decompressed_path)?;
+        std::io::copy(&mut decoder, &mut out_file)?;
+        std::fs::remove_file(path)?;
+    } else {
+        let tmp_path = path.with_extension("tmp");
+        let mut out_file = std::fs::File::create(&tmp_path)?;
+        std::io::copy(&mut decoder, &mut out_file)?;
+        drop(out_file);
+        std::fs::rename(&tmp_path, path)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -839,6 +874,7 @@ mod tests {
 
     #[test]
     fn test_vec_to_hashmap_empty_vector() {
+
         let input = Some(vec![]);
 
         let result = vec_to_hashmap(input);

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
+use flate2::read::GzDecoder;
 use futures::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use reqwest::{Body, Client, StatusCode};
@@ -13,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 use time::OffsetDateTime;
-use flate2::read::GzDecoder;
 use tokio::fs::{create_dir_all, File};
 use tokio::io;
 
@@ -874,7 +874,6 @@ mod tests {
 
     #[test]
     fn test_vec_to_hashmap_empty_vector() {
-
         let input = Some(vec![]);
 
         let result = vec_to_hashmap(input);

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -156,12 +156,13 @@ async fn patch_file(path: &Path) -> io::Result<()> {
         for attachment in attachments {
             if let Some(source) = attachment.get_mut("source") {
                 if let Some(source_str) = source.as_str() {
-                    // touch only logs and video
-                    if let Some(index) = source_str
+                    let stripped = source_str.strip_suffix(".gz").unwrap_or(source_str);
+                    if let Some(index) = stripped
                         .find("logs/omni")
-                        .or_else(|| source_str.find("video/omni"))
+                        .or_else(|| stripped.find("device-logs/omni"))
+                        .or_else(|| stripped.find("video/omni"))
                     {
-                        let new_path = format!("../../{}", &source_str[index..]);
+                        let new_path = format!("../../{}", &stripped[index..]);
                         *source = Value::String(new_path);
                     }
                 }


### PR DESCRIPTION
uncompresses on the fly when using download

before this version users can use `find ./ -name '*.gz' -exec gunzip {} +` to unpack existing files, but this doesn't patch the allure report paths, so the only proper solution is upgrading to newer client